### PR TITLE
Corrigindo Application Filter Cors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>com.example</groupId>
 	<artifactId>produtos-api</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>produtos-api</name>
 	<description>Projeto De Exemplo Spring Boot</description>
 

--- a/src/main/java/com/example/produtosapi/conf/CorsFilter.java
+++ b/src/main/java/com/example/produtosapi/conf/CorsFilter.java
@@ -1,0 +1,46 @@
+package com.example.produtosapi.conf;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorsFilter implements Filter {
+	
+	@Override
+	public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain) throws IOException, ServletException {
+		
+		HttpServletResponse response = (HttpServletResponse) resp;
+        HttpServletRequest request = (HttpServletRequest) req;
+        
+        String origem = request.getHeader("Origin");
+        
+        // TODO Adicionar apenas origens permitidas, para melhor segurança
+        if(origem == null) { origem = "*"; }
+        
+        response.setHeader("Access-Control-Allow-Origin", origem);
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, PUT, OPTIONS");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+        response.setHeader("Access-Control-Max-Age", "3600");
+    	response.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept");
+
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            response.setStatus(HttpServletResponse.SC_OK);
+        } else {
+            chain.doFilter(req, resp);
+        }
+		
+	}
+	
+}


### PR DESCRIPTION
Adicionado um filtro antes das requisições, para poder permitir a comunicação com origens sendo executadas em portas sem, ser as padrões do protocolo.